### PR TITLE
Dockerize 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+Dockerfile
+.git
+.hg
+.svn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.5
+
+# Install chinese fonts, then update the font-cache.
+# Based on: http://cnedelcu.blogspot.com/2015/04/wkhtmltopdf-chinese-character-support.html
+RUN apt-get update && apt-get install --no-install-recommends -yq \
+    fonts-wqy-microhei \
+    ttf-wqy-microhei \
+    fonts-wqy-zenhei \
+    ttf-wqy-zenhei
+RUN fc-cache -f -v
+
+RUN mkdir -p /zendesk-utils
+COPY requirements.txt /zendesk-utils
+RUN pip install --no-cache-dir -r /zendesk-utils/requirements.txt
+
+ENV PYTHONPATH /zendesk-utils:/zendesk-utils/helpcenter_to_pdf:/zendesk-utils/to_json:/zendesk-utils/localize:$PYTHONPATH
+
+COPY . /zendesk-utils
+WORKDIR /zendesk-utils

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+#
+# Usage:
+#     make dev
+#     make build
+
+help:
+	@echo 'Makefile for zendesk-utils                      '
+	@echo '                                                                '
+	@echo '   make dev                      Run /bin/bash in a machine that can run these utils'
+
+.PHONY: dev build
+
+IMAGE_NAME = gaiagps/zendesk-utils
+
+dev: build
+	docker run --privileged --rm -ti -v `pwd`:/zendesk-utils gaiagps/zendesk-utils /bin/bash
+
+build:
+	docker build -t $(IMAGE_NAME) .

--- a/localize/_sample_project_settings.py
+++ b/localize/_sample_project_settings.py
@@ -1,9 +1,9 @@
 '''
     zendesk config
 '''
-ZENDESK_SUBDOMAIN = 'your_zendesk_domain'                
-ZENDESK_EMAIL = 'you@example.com'                       
-ZENDESK_TOKEN = ''                 
+ZENDESK_SUBDOMAIN = 'your_zendesk_domain'
+ZENDESK_EMAIL = 'you@example.com'
+ZENDESK_TOKEN = ''
 
 '''
     gengo config
@@ -12,7 +12,7 @@ GENGO_PUBLIC_KEY = ''
 GENGO_PRIVATE_KEY = ''
 GENGO_API_URL = 'http://api.gengo.com/v2/translate/'
 TRANSLATION_RESPONSE_DIR = "gen/gengo_translations/"
-    
+
 '''
     gengo sandbox config
 '''
@@ -25,16 +25,16 @@ if GENGO_DEBUG:
 '''
     select articles/words/sections/categories to translate
 '''
-DATA_CONFIG = {
-  unlocalized_words: [],            # REQUIRED
-	locales_to_translate: [],         # REQUIRED
-  category_blacklist_for_pdfs: [],  # config if batch localizing 
-	included_categories: [],          # config if batch localizing 
-	included_sections: [],            # config if batch localizing 
-	whitelist_articles: [],           # config if batch localizing 
-	blacklist_articles: [],           # config if batch localizing 
-}
-# EXAMPLE locales_to_translate: ['zh-cn', 'zh-tw', 'nl', 'fr-fr', 'fr-CA', 'de', 'it', 'pt', 'pt-BR', 'ru', 'es-419', 'es-ES', 'sv', 'tr' ]  
+DATA_CONFIG = dict(
+  unlocalized_words = [],            # REQUIRED
+  locales_to_translate = [],         # REQUIRED
+  category_blacklist_for_pdfs = [],  # config if batch localizing
+  included_categories = [],          # config if batch localizing
+  included_sections = [],            # config if batch localizing
+  whitelist_articles = [],           # config if batch localizing
+  blacklist_articles = [],           # config if batch localizing
+)
+# EXAMPLE locales_to_translate: ['zh-cn', 'zh-tw', 'nl', 'fr-fr', 'fr-CA', 'de', 'it', 'pt', 'pt-BR', 'ru', 'es-419', 'es-ES', 'sv', 'tr' ]
 
 
 '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+beautifulsoup4==4.4.1
+boto==2.39.0
+requests==2.9.1
+
+# use this because pdfkit otherwise puts ToC before cover
+# see: https://github.com/JazzCore/python-pdfkit/pull/23
+git+git://github.com/signalkraft/python-pdfkit.git@b30c104b4db93d7f12ade018473c57779ac2a77e

--- a/to_json/ZendeskJsonPackager.py
+++ b/to_json/ZendeskJsonPackager.py
@@ -6,7 +6,7 @@ class ZendeskJsonPackager:
   '''
       package zendesk help center articles into JSON
       utility for localization and pdification
-  '''  
+  '''
 
   def __init__(self, article_id):
     print("STARTING: fetching JSON from Zendesk for localization")
@@ -16,7 +16,7 @@ class ZendeskJsonPackager:
     self.zendesk_session.headers = {'Content-Type': 'application/json'}
 
     self.package_zendesk_for_gengo_localization(article_id)
-    
+
 
   def package_zendesk_for_gengo_localization(self, article_id=None):
     '''
@@ -72,7 +72,7 @@ class ZendeskJsonPackager:
       return self.articles;
     else:
       print ("ZENDESK API: fetching articles: {}".format(self.zendesk_url))
-   
+
     url = '{}/articles.json'.format(self.zendesk_url)
     self.articles = []
     self.articles_done_fetching = False;
@@ -87,7 +87,7 @@ class ZendeskJsonPackager:
       for article in articles:
         self.articles.append(article)
       url = response.json()['next_page']
-  
+
     self.articles_done_fetching = True;
     return self.articles;
 
@@ -120,16 +120,16 @@ class ZendeskJsonPackager:
     sections = self.fetch_all_sections()
     included_sections = self.included_sections()
     json_dict = {}
-    
+
     # only include sections from whitelisted categories
     with open('gen/category_names.json', 'r') as category_file:
       category_dict = json.load(category_file)
 
     for section in sections:
       category_name = category_dict[str(section['category_id'])]['name']
-      json_dict[section['id']] = {'localize':self.should_localize_section(section, article_id), 
-                                  'name':section['name'], 
-                                  'category_id':section['category_id'], 
+      json_dict[section['id']] = {'localize':self.should_localize_section(section, article_id),
+                                  'name':section['name'],
+                                  'category_id':section['category_id'],
                                   'category':category_name
                                  }
 
@@ -200,20 +200,20 @@ class ZendeskJsonPackager:
       category_dict = json.load(category_file)
     with open('gen/section_names.json', 'r') as category_file:
       section_dict = json.load(category_file)
-    
+
     if article_id:
       for article in self.fetch_all_articles():
         if article_id == str(article['id']):
           section_id = str(article['section_id'])
           category_id = str(section_dict[section_id]['category_id'])
-          json_dict[article['id']] = {'title': article['title'], 
-                                    'category': category_dict[category_id]['name'], 
-                                    'category_id': category_id, 
-                                    'section': section_dict[section_id]['name'], 
-                                    'section_id': article['section_id'], 
-                                    'section': section_dict[section_id]['name'], 
-                                    'should_localize': True, 
-                                    'html_url': article['html_url'],    
+          json_dict[article['id']] = {'title': article['title'],
+                                    'category': category_dict[category_id]['name'],
+                                    'category_id': category_id,
+                                    'section': section_dict[section_id]['name'],
+                                    'section_id': article['section_id'],
+                                    'section': section_dict[section_id]['name'],
+                                    'should_localize': True,
+                                    'html_url': article['html_url'],
                                     'url': article['url']    }
           break
     else:
@@ -228,14 +228,14 @@ class ZendeskJsonPackager:
           continue
         elif not category_dict[category_id]['localize']:
           continue
-        json_dict[article['id']] = {'title': article['title'], 
-                                    'category': category_dict[category_id]['name'], 
-                                    'category_id': category_id, 
-                                    'section': section_dict[section_id]['name'], 
-                                    'section_id': article['section_id'], 
-                                    'section': section_dict[section_id]['name'], 
-                                    'should_localize': True, 
-                                    'html_url': article['html_url'],    
+        json_dict[article['id']] = {'title': article['title'],
+                                    'category': category_dict[category_id]['name'],
+                                    'category_id': category_id,
+                                    'section': section_dict[section_id]['name'],
+                                    'section_id': article['section_id'],
+                                    'section': section_dict[section_id]['name'],
+                                    'should_localize': True,
+                                    'html_url': article['html_url'],
                                     'url': article['url']    }
 
     with open('gen/article_info.json', 'w') as outfile:


### PR DESCRIPTION
This includes a Dockerfile based on python3.5, that installs the chinese fonts and all python requirements.

This also upgrades ZendeskPDFMaker.py to python3, namely:
sys.maxint -> sys.maxsize
urlparse -> urllib.parse
along with ()s for print

Running `make dev` from /zendesk-utils will build a docker image called gaiagps/zendesk-utils and put you running /bin/bash at /zendesk-utils inside the container.

Then running:
python helpcenter_to_pdf/ZendeskPDFMaker.py create 
will properly import everything, but stops on an error beyond the scope of this pull request, namely:
File "helpcenter_to_pdf/ZendeskPDFMaker.py", line 35, in create_pdfs
    self.json_packager = ZendeskJsonPackager()
TypeError: __init__() missing 1 required positional argument: 'article_id'