### PR TITLE
paginate api calls

### DIFF
--- a/to_json/ZendeskJsonPackager.py
+++ b/to_json/ZendeskJsonPackager.py
@@ -39,7 +39,6 @@ class ZendeskJsonPackager:
 
     url = '{}/categories.json'.format(self.zendesk_url)
     self.categories = []
-    self.categories_done_fetching = False
 
     # page through all categories, 30 at a time
     while url:
@@ -53,7 +52,6 @@ class ZendeskJsonPackager:
         self.categories.append(category)
       url = response.json()['next_page']
     
-    self.categories_done_fetching = True
     return self.categories
 
 
@@ -68,7 +66,6 @@ class ZendeskJsonPackager:
 
     url = '{}/sections.json'.format(self.zendesk_url)
     self.sections = []
-    self.sections_done_fetching = False
 
     # page through all sections, 30 at a time
     while url:
@@ -82,7 +79,6 @@ class ZendeskJsonPackager:
         self.sections.append(section)
       url = response.json()['next_page']
     
-    self.sections_done_fetching = True
     return self.sections
 
 
@@ -97,7 +93,6 @@ class ZendeskJsonPackager:
 
     url = '{}/articles.json'.format(self.zendesk_url)
     self.articles = []
-    self.articles_done_fetching = False
 
     # page through all articles, 30 at a time
     while url:
@@ -110,7 +105,6 @@ class ZendeskJsonPackager:
         self.articles.append(article)
       url = response.json()['next_page']
 
-    self.articles_done_fetching = True
     return self.articles
 
 

--- a/to_json/ZendeskJsonPackager.py
+++ b/to_json/ZendeskJsonPackager.py
@@ -38,11 +38,22 @@ class ZendeskJsonPackager:
       print ("ZENDESK API: fetching categories")
 
     url = '{}/categories.json'.format(self.zendesk_url)
-    response = self.zendesk_session.get(url)
-    if response.status_code != 200:
-      print('FAILED to get category list with error {}'.format(response.status_code))
-      exit()
-    self.categories = response.json()['categories']
+    self.categories = []
+    self.categories_done_fetching = False
+
+    # page through all categories, 30 at a time
+    while url:
+      response = self.zendesk_session.get(url)
+      if response.status_code != 200:
+        print('FAILED to get category list with error {}'.format(response.status_code))
+        exit()
+    
+      categories = response.json()['categories']
+      for category in categories:
+        self.categories.append(category)
+      url = response.json()['next_page']
+    
+    self.categories_done_fetching = True
     return self.categories
 
 
@@ -55,12 +66,23 @@ class ZendeskJsonPackager:
     else:
       print ("ZENDESK API: fetching sections")
 
-    url = '{}/sections.json'.format(self.zendesk_url) + '?page[size]=100'
-    response = self.zendesk_session.get(url)
-    if response.status_code != 200:
-      print('FAILED to get section list with error {}'.format(response.status_code))
-      exit()
-    self.sections = response.json()['sections']
+    url = '{}/sections.json'.format(self.zendesk_url)
+    self.sections = []
+    self.sections_done_fetching = False
+
+    # page through all sections, 30 at a time
+    while url:
+      response = self.zendesk_session.get(url)
+      if response.status_code != 200:
+        print('FAILED to get section list with error {}'.format(response.status_code))
+        exit()
+    
+      sections = response.json()['sections']
+      for section in sections:
+        self.sections.append(section)
+      url = response.json()['next_page']
+    
+    self.sections_done_fetching = True
     return self.sections
 
 


### PR DESCRIPTION
Fixes: https://github.com/trailbehind/zendesk-utils/issues/10

Test plan: 

- [X] Confirm PDFs are successfully generated
- [X] Confirm 32 sections are returned in the section_names.json file
- [X] Confirm 6 categories are returned in the category_names.json file